### PR TITLE
[codex] Improve vintage knob GUI

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -59,7 +59,7 @@ TubePreampPluginAudioProcessorEditor::TubePreampPluginAudioProcessorEditor(
 
     // Drive Slider
     driveSlider.setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
-    driveSlider.setTextBoxStyle(juce::Slider::TextBoxBelow, true, 50, 16);
+    driveSlider.setTextBoxStyle(juce::Slider::TextBoxBelow, true, 58, 18);
     driveSlider.setLookAndFeel(&vintageLNF);
     {
         juce::Slider::RotaryParameters rp;
@@ -81,12 +81,13 @@ TubePreampPluginAudioProcessorEditor::TubePreampPluginAudioProcessorEditor(
     // Drive Label
     driveLabel.setText("DRIVE", juce::dontSendNotification);
     driveLabel.setJustificationType(juce::Justification::centred);
-    driveLabel.setColour(juce::Label::textColourId, juce::Colours::white);
+    driveLabel.setFont(juce::Font(13.0f, juce::Font::bold));
+    driveLabel.setColour(juce::Label::textColourId, juce::Colour::fromRGB(255, 238, 190));
     addAndMakeVisible(driveLabel);
 
     // Output Slider
     outputSlider.setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
-    outputSlider.setTextBoxStyle(juce::Slider::TextBoxBelow, true, 50, 16);
+    outputSlider.setTextBoxStyle(juce::Slider::TextBoxBelow, true, 58, 18);
     outputSlider.setLookAndFeel(&vintageLNF);
     {
         juce::Slider::RotaryParameters rp;
@@ -108,12 +109,13 @@ TubePreampPluginAudioProcessorEditor::TubePreampPluginAudioProcessorEditor(
     // Output Label
     outputLabel.setText("OUTPUT", juce::dontSendNotification);
     outputLabel.setJustificationType(juce::Justification::centred);
-    outputLabel.setColour(juce::Label::textColourId, juce::Colours::white);
+    outputLabel.setFont(juce::Font(13.0f, juce::Font::bold));
+    outputLabel.setColour(juce::Label::textColourId, juce::Colour::fromRGB(255, 238, 190));
     addAndMakeVisible(outputLabel);
 
     // Bias Slider
     biasSlider.setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
-    biasSlider.setTextBoxStyle(juce::Slider::TextBoxBelow, true, 50, 16);
+    biasSlider.setTextBoxStyle(juce::Slider::TextBoxBelow, true, 58, 18);
     biasSlider.setLookAndFeel(&vintageLNF);
     {
         juce::Slider::RotaryParameters rp;
@@ -152,7 +154,8 @@ TubePreampPluginAudioProcessorEditor::TubePreampPluginAudioProcessorEditor(
     // Bias Label
     biasLabel.setText("BIAS", juce::dontSendNotification);
     biasLabel.setJustificationType(juce::Justification::centred);
-    biasLabel.setColour(juce::Label::textColourId, juce::Colours::white);
+    biasLabel.setFont(juce::Font(13.0f, juce::Font::bold));
+    biasLabel.setColour(juce::Label::textColourId, juce::Colour::fromRGB(255, 238, 190));
     addAndMakeVisible(biasLabel);
 }
 
@@ -173,12 +176,20 @@ void TubePreampPluginAudioProcessorEditor::paint(juce::Graphics& g) {
     else
         g.fillAll(juce::Colour::fromRGB(18, 12, 38)); // deep indigo fallback
 
+    auto controlShelf = getLocalBounds().reduced(18);
+    controlShelf.removeFromTop(172);
+    controlShelf.reduce(10, 8);
+    g.setColour(juce::Colours::black.withAlpha(0.14f));
+    g.fillRoundedRectangle(controlShelf.toFloat(), 7.0f);
+    g.setColour(juce::Colour::fromRGB(205, 164, 72).withAlpha(0.42f));
+    g.drawRoundedRectangle(controlShelf.toFloat().reduced(0.5f), 7.0f, 1.0f);
+
     // Header/title area, text centered but avoiding actual logo/tube bounds
     auto inner = getLocalBounds().reduced(20);
     auto header = inner.removeFromTop(160);
 
-    g.setColour(juce::Colours::white);
-    g.setFont(26.0f);
+    g.setColour(juce::Colour::fromRGB(255, 244, 214));
+    g.setFont(juce::Font(25.0f, juce::Font::bold));
 
     // Compute actual reserved widths (replicate draw logic)
     int leftReserve = 0;
@@ -266,23 +277,23 @@ void TubePreampPluginAudioProcessorEditor::resized() {
 
     // Controls area
     auto area = bounds.reduced(10);
-    const int labelH = 18;
+    const int labelH = 20;
     const int columns = 3;
-    int gap = 24; // start with a comfortable gap
+    int gap = 32; // start with a comfortable gap
 
     const int areaW = area.getWidth();
     const int areaH = area.getHeight();
     auto computeColW = [&](int g) { return (areaW - (columns - 1) * g) / columns; };
 
     int colW = computeColW(gap);
-    if (colW < 150) { gap = 16; colW = computeColW(gap); }
-    if (colW < 150) { gap = 8;  colW = computeColW(gap); }
+    if (colW < 150) { gap = 22; colW = computeColW(gap); }
+    if (colW < 150) { gap = 12; colW = computeColW(gap); }
     colW = juce::jmax(colW, 120);
 
-    const int padX = 10;
+    const int padX = 14;
     const int knobMaxByWidth  = colW - padX * 2;
-    const int knobMaxByHeight = areaH - labelH - 30;
-    const int knobSize = juce::jlimit(110, 180, juce::jmin(knobMaxByWidth, knobMaxByHeight));
+    const int knobMaxByHeight = areaH - labelH - 34;
+    const int knobSize = juce::jlimit(104, 142, juce::jmin(knobMaxByWidth, knobMaxByHeight));
 
     // Recalculate colW to match chosen knobSize
     colW = knobSize + padX * 2;
@@ -293,8 +304,8 @@ void TubePreampPluginAudioProcessorEditor::resized() {
     auto place = [&](juce::Label& lbl, juce::Slider& s, int idx) {
         juce::Rectangle<int> col(startX + idx * (colW + gap), topY, colW, areaH);
         lbl.setBounds(col.removeFromTop(labelH));
-        col.reduce(padX, 6);
-        col.setSize(col.getWidth(), knobSize + 26); // knob plus textbox space
+        col.reduce(padX, 8);
+        col.setSize(col.getWidth(), knobSize + 30); // knob plus textbox space
         s.setBounds(col);
     };
 

--- a/Source/VintageLookAndFeel.cpp
+++ b/Source/VintageLookAndFeel.cpp
@@ -1,169 +1,150 @@
-// --------------------
-// Source/VintageLookAndFeel.cpp
-// --------------------
 #include "VintageLookAndFeel.h"
 
-static juce::Colour withGain(juce::Colour c, float gain) {
-    return juce::Colour::fromFloatRGBA(
-        juce::jlimit<float>(0.0f, 1.0f, c.getFloatRed()   * gain),
-        juce::jlimit<float>(0.0f, 1.0f, c.getFloatGreen() * gain),
-        juce::jlimit<float>(0.0f, 1.0f, c.getFloatBlue()  * gain),
-        c.getFloatAlpha());
+VintageLookAndFeel::VintageLookAndFeel()
+{
+    setColour(juce::Slider::textBoxTextColourId, juce::Colour::fromRGB(250, 238, 199));
+    setColour(juce::Slider::textBoxBackgroundColourId, juce::Colour::fromRGB(39, 24, 72));
+    setColour(juce::Slider::textBoxOutlineColourId, juce::Colour::fromRGB(191, 159, 76));
+    setColour(juce::Slider::textBoxHighlightColourId, juce::Colour::fromRGB(117, 49, 79));
 }
 
 void VintageLookAndFeel::drawRotarySlider(juce::Graphics& g, int x, int y, int width, int height,
                                           float sliderPosProportional, float rotaryStartAngle,
                                           float rotaryEndAngle, juce::Slider& slider)
 {
+    juce::ignoreUnused(slider);
+
     const auto bounds = juce::Rectangle<int>(x, y, width, height).toFloat();
     const auto centre = bounds.getCentre();
     const float diameter = juce::jmin(bounds.getWidth(), bounds.getHeight());
     const float radius = diameter * 0.5f;
-    const float pad = juce::jmax(4.0f, diameter * 0.08f);
-    const float rOuter = radius - pad;
-    const float rInner = rOuter * 0.72f;
-
-    // Angles
+    const float pad = juce::jmax(7.0f, diameter * 0.10f);
+    const float rScale = radius - 3.0f;
+    const float rOuter = radius - pad - 3.0f;
+    const float rFace = rOuter * 0.74f;
+    const float rHub = rFace * 0.23f;
     const float angle = rotaryStartAngle + sliderPosProportional * (rotaryEndAngle - rotaryStartAngle);
 
     g.setImageResamplingQuality(juce::Graphics::highResamplingQuality);
-    g.setOpacity(1.0f);
 
-    // Drop shadow ellipse
+    // Brass dial scale behind the knob, so the control reads on the dark velvet.
     {
-        juce::Path shadow;
-        shadow.addEllipse(centre.x - rOuter, centre.y - rOuter + 2.0f, rOuter * 2.0f, rOuter * 2.0f);
-        g.setColour(juce::Colours::black.withAlpha(0.25f));
-        g.fillPath(shadow);
-    }
+        juce::Path scaleArc;
+        scaleArc.addCentredArc(centre.x, centre.y, rScale, rScale, 0.0f,
+                               rotaryStartAngle, rotaryEndAngle, true);
+        g.setColour(juce::Colour::fromRGB(154, 112, 42).withAlpha(0.42f));
+        g.strokePath(scaleArc, juce::PathStrokeType(2.2f, juce::PathStrokeType::curved,
+                                                   juce::PathStrokeType::rounded));
 
-    // Skirt (outer ring) — Fairchild bakelite with rim highlight
-    {
-        juce::Colour cDark(10, 10, 12);
-        juce::Colour cLight(58, 58, 62);
-        juce::ColourGradient grad(cLight, centre.x - rOuter * 0.3f, centre.y - rOuter * 0.3f,
-                                  cDark, centre.x + rOuter * 0.8f, centre.y + rOuter * 0.8f, true);
-        g.setGradientFill(grad);
-        g.fillEllipse(centre.x - rOuter, centre.y - rOuter, rOuter * 2.0f, rOuter * 2.0f);
-
-        // Outer rim
-        g.setColour(juce::Colours::black.withAlpha(0.8f));
-        g.drawEllipse(centre.x - rOuter, centre.y - rOuter, rOuter * 2.0f, rOuter * 2.0f, 1.5f);
-
-        // Inner rim
-        g.setColour(juce::Colours::grey.withAlpha(0.4f));
-        g.drawEllipse(centre.x - rInner, centre.y - rInner, rInner * 2.0f, rInner * 2.0f, 1.0f);
-    }
-
-    // Scalloped knurl on skirt (deep flutes)
-    {
-        const int flutes = 16; // large scallops
-        const float inner = rOuter * 0.80f;
-        for (int i = 0; i < flutes; ++i)
-        {
-            const float a = juce::MathConstants<float>::twoPi * (float) i / (float) flutes;
-            const float nx = std::cos(a), ny = std::sin(a);
-            auto p0 = juce::Point<float>(centre.x + nx * (inner - 1.0f), centre.y + ny * (inner - 1.0f));
-            auto p1 = juce::Point<float>(centre.x + nx * (rOuter - 1.0f), centre.y + ny * (rOuter - 1.0f));
-
-            // Shadow stroke
-            g.setColour(juce::Colours::black.withAlpha(0.35f));
-            g.drawLine({ p0, p1 }, 2.0f);
-            // Highlight stroke slightly offset
-            g.setColour(juce::Colours::white.withAlpha(0.08f));
-            g.drawLine({ p0 + juce::Point<float>(-ny, nx) * 1.0f, p1 + juce::Point<float>(-ny, nx) * 1.0f }, 1.2f);
-        }
-    }
-
-    // Face (inner disk) — black face, subtle dome and specular
-    {
-        juce::Colour faceBase = juce::Colour::fromRGB(22, 22, 24);
-        juce::Colour faceHi   = juce::Colour::fromRGB(64, 64, 70);
-        juce::ColourGradient face(faceHi, centre.x - rInner * 0.25f, centre.y - rInner * 0.25f,
-                                  faceBase, centre.x + rInner * 0.6f, centre.y + rInner * 0.6f, true);
-        g.setGradientFill(face);
-        g.fillEllipse(centre.x - rInner, centre.y - rInner, rInner * 2.0f, rInner * 2.0f);
-
-        // Specular sweep
-        juce::Path sweep; sweep.addPieSegment(centre.x - rInner, centre.y - rInner, rInner * 2.0f, rInner * 2.0f,
-                                              -juce::MathConstants<float>::halfPi * 0.8f,
-                                              -juce::MathConstants<float>::halfPi * 0.3f,
-                                              0.14f);
-        g.setColour(juce::Colours::white.withAlpha(0.06f));
-        g.fillPath(sweep);
-    }
-
-    // Index tick ring on panel (subtle)
-    {
-        const float ringR = rOuter + 6.0f;
-        const int ticks = 11; // includes center
+        const int ticks = 13;
         for (int i = 0; i < ticks; ++i)
         {
             const float t = (float) i / (float) (ticks - 1);
             const float a = rotaryStartAngle + t * (rotaryEndAngle - rotaryStartAngle);
-            juce::Point<float> p0(centre.x + std::cos(a) * (ringR - 5.0f), centre.y + std::sin(a) * (ringR - 5.0f));
-            juce::Point<float> p1(centre.x + std::cos(a) * (ringR - 2.0f), centre.y + std::sin(a) * (ringR - 2.0f));
-            const bool endTick = (i == 0 || i == ticks - 1);
-            const bool midTick = (i == (ticks - 1) / 2);
-            g.setColour(juce::Colours::white.withAlpha(midTick ? 0.22f : (endTick ? 0.16f : 0.10f)));
-            g.drawLine({ p0, p1 }, midTick ? 1.3f : (endTick ? 1.0f : 0.8f));
+            const bool major = (i == 0 || i == ticks - 1 || i == (ticks - 1) / 2);
+            const float tickLen = major ? 8.0f : 4.5f;
+            const auto p0 = juce::Point<float>(centre.x + std::cos(a) * (rScale - tickLen),
+                                               centre.y + std::sin(a) * (rScale - tickLen));
+            const auto p1 = juce::Point<float>(centre.x + std::cos(a) * rScale,
+                                               centre.y + std::sin(a) * rScale);
+            g.setColour(juce::Colour::fromRGB(241, 210, 129).withAlpha(major ? 0.80f : 0.48f));
+            g.drawLine({ p0, p1 }, major ? 1.6f : 1.0f);
         }
     }
 
-    // Pointer — Fairchild-style cream wedge on black face
+    g.setColour(juce::Colours::black.withAlpha(0.32f));
+    g.fillEllipse(centre.x - rOuter, centre.y - rOuter + 4.0f, rOuter * 2.0f, rOuter * 2.0f);
+
+    // Thin black bakelite skirt.
     {
-        const float pr0 = rInner * 0.18f;    // inner start
-        const float pr1 = rInner * 0.96f;    // to rim
-        const float halfA = juce::jlimit<float>(0.06f, 0.12f, rInner * 0.0008f + 0.09f); // wedge half-angle
+        juce::ColourGradient skirt(juce::Colour::fromRGB(62, 58, 62),
+                                   centre.x - rOuter * 0.45f, centre.y - rOuter * 0.55f,
+                                   juce::Colour::fromRGB(8, 8, 10),
+                                   centre.x + rOuter * 0.55f, centre.y + rOuter * 0.70f, true);
+        g.setGradientFill(skirt);
+        g.fillEllipse(centre.x - rOuter, centre.y - rOuter, rOuter * 2.0f, rOuter * 2.0f);
 
-        juce::Path wedge;
-        auto p0 = juce::Point<float>(centre.x + std::cos(angle - halfA) * pr0,
-                                     centre.y + std::sin(angle - halfA) * pr0);
-        auto p1 = juce::Point<float>(centre.x + std::cos(angle + halfA) * pr0,
-                                     centre.y + std::sin(angle + halfA) * pr0);
-        auto p2 = juce::Point<float>(centre.x + std::cos(angle + halfA * 0.9f) * pr1,
-                                     centre.y + std::sin(angle + halfA * 0.9f) * pr1);
-        auto p3 = juce::Point<float>(centre.x + std::cos(angle - halfA * 0.9f) * pr1,
-                                     centre.y + std::sin(angle - halfA * 0.9f) * pr1);
-        wedge.startNewSubPath(p0); wedge.lineTo(p1); wedge.lineTo(p2); wedge.lineTo(p3); wedge.closeSubPath();
+        const int ridges = 36;
+        for (int i = 0; i < ridges; ++i)
+        {
+            const float a = juce::MathConstants<float>::twoPi * (float) i / (float) ridges;
+            const float inner = rOuter * 0.84f;
+            const float outer = rOuter * 0.98f;
+            const auto p0 = juce::Point<float>(centre.x + std::cos(a) * inner,
+                                               centre.y + std::sin(a) * inner);
+            const auto p1 = juce::Point<float>(centre.x + std::cos(a) * outer,
+                                               centre.y + std::sin(a) * outer);
+            g.setColour((i % 2 == 0 ? juce::Colours::white : juce::Colours::black).withAlpha(i % 2 == 0 ? 0.075f : 0.25f));
+            g.drawLine({ p0, p1 }, 1.0f);
+        }
 
-        // Antique ivory tone
-        juce::Colour ivory(236, 224, 188);
-        juce::Colour ivoryEdge(208, 194, 160);
-        juce::ColourGradient wg(ivory, (p0.x + p1.x) * 0.5f, (p0.y + p1.y) * 0.5f,
-                                ivoryEdge, (p2.x + p3.x) * 0.5f, (p2.y + p3.y) * 0.5f, false);
-        g.setGradientFill(wg);
-        g.fillPath(wedge);
-        g.setColour(juce::Colours::black.withAlpha(0.25f));
-        g.strokePath(wedge, juce::PathStrokeType(0.9f));
-
-        // Fine center line on wedge
-        juce::Point<float> c0(centre.x + std::cos(angle) * pr0, centre.y + std::sin(angle) * pr0);
-        juce::Point<float> c1(centre.x + std::cos(angle) * pr1, centre.y + std::sin(angle) * pr1);
-        g.setColour(juce::Colours::white.withAlpha(0.22f));
-        g.drawLine({ c0, c1 }, 0.7f);
+        g.setColour(juce::Colours::black.withAlpha(0.82f));
+        g.drawEllipse(centre.x - rOuter, centre.y - rOuter, rOuter * 2.0f, rOuter * 2.0f, 1.8f);
+        g.setColour(juce::Colour::fromRGB(230, 195, 103).withAlpha(0.65f));
+        g.drawEllipse(centre.x - rOuter + 2.5f, centre.y - rOuter + 2.5f,
+                      (rOuter - 2.5f) * 2.0f, (rOuter - 2.5f) * 2.0f, 1.0f);
     }
 
-    // Center screw (chrome with slot)
+    // Champagne face: intentionally kitsch, but brighter and cleaner than the old black disk.
     {
-        const float capR = rInner * 0.22f;
-        juce::Colour c0 = juce::Colour::fromRGB(210, 210, 210);
-        juce::Colour c1 = juce::Colour::fromRGB(120, 120, 120);
-        juce::ColourGradient grad(c0, centre.x, centre.y - capR * 0.7f,
-                                  c1, centre.x, centre.y + capR * 0.9f, true);
-        g.setGradientFill(grad);
-        g.fillEllipse(centre.x - capR, centre.y - capR, capR * 2.0f, capR * 2.0f);
-        g.setColour(juce::Colours::black.withAlpha(0.5f));
-        g.drawEllipse(centre.x - capR, centre.y - capR, capR * 2.0f, capR * 2.0f, 1.0f);
+        juce::ColourGradient face(juce::Colour::fromRGB(253, 237, 190),
+                                  centre.x - rFace * 0.35f, centre.y - rFace * 0.45f,
+                                  juce::Colour::fromRGB(142, 94, 42),
+                                  centre.x + rFace * 0.70f, centre.y + rFace * 0.75f, true);
+        g.setGradientFill(face);
+        g.fillEllipse(centre.x - rFace, centre.y - rFace, rFace * 2.0f, rFace * 2.0f);
 
-        // Slot
-        const float slotW = juce::jmax(1.2f, capR * 0.20f);
-        const float slotL = capR * 1.4f;
-        juce::Path slot; slot.startNewSubPath(centre.x - slotL * 0.5f, centre.y);
-        slot.lineTo(centre.x + slotL * 0.5f, centre.y);
-        g.setColour(juce::Colours::black.withAlpha(0.75f));
-        g.strokePath(slot, juce::PathStrokeType(slotW, juce::PathStrokeType::curved, juce::PathStrokeType::rounded));
-        g.setColour(juce::Colours::white.withAlpha(0.25f));
-        g.strokePath(slot, juce::PathStrokeType(slotW * 0.4f));
+        g.setColour(juce::Colour::fromRGB(58, 30, 28).withAlpha(0.46f));
+        g.drawEllipse(centre.x - rFace, centre.y - rFace, rFace * 2.0f, rFace * 2.0f, 1.2f);
+
+        juce::Path gloss;
+        gloss.addPieSegment(centre.x - rFace, centre.y - rFace, rFace * 2.0f, rFace * 2.0f,
+                            -2.45f, -0.80f, 0.18f);
+        g.setColour(juce::Colours::white.withAlpha(0.18f));
+        g.fillPath(gloss);
+    }
+
+    // Slim ruby pointer with a brass cap. It is loud, but much more legible.
+    {
+        const float baseR = rHub * 0.55f;
+        const float tipR = rFace * 0.88f;
+        const float halfW = juce::jmax(2.4f, rFace * 0.055f);
+        const auto tangent = juce::Point<float>(-std::sin(angle), std::cos(angle));
+        const auto base = juce::Point<float>(centre.x + std::cos(angle) * baseR,
+                                             centre.y + std::sin(angle) * baseR);
+        const auto tip = juce::Point<float>(centre.x + std::cos(angle) * tipR,
+                                            centre.y + std::sin(angle) * tipR);
+
+        juce::Path pointer;
+        pointer.startNewSubPath(base + tangent * halfW);
+        pointer.lineTo(tip);
+        pointer.lineTo(base - tangent * halfW);
+        pointer.closeSubPath();
+
+        juce::ColourGradient ruby(juce::Colour::fromRGB(255, 68, 66), base.x, base.y,
+                                  juce::Colour::fromRGB(108, 14, 33), tip.x, tip.y, false);
+        g.setGradientFill(ruby);
+        g.fillPath(pointer);
+        g.setColour(juce::Colours::black.withAlpha(0.45f));
+        g.strokePath(pointer, juce::PathStrokeType(0.9f, juce::PathStrokeType::curved,
+                                                  juce::PathStrokeType::rounded));
+
+        g.setColour(juce::Colour::fromRGB(255, 236, 178).withAlpha(0.75f));
+        g.drawLine({ base + tangent * (halfW * 0.25f), tip - tangent * (halfW * 0.15f) }, 0.8f);
+    }
+
+    // Center cap.
+    {
+        juce::ColourGradient cap(juce::Colour::fromRGB(255, 226, 148),
+                                 centre.x - rHub * 0.35f, centre.y - rHub * 0.45f,
+                                 juce::Colour::fromRGB(103, 63, 28),
+                                 centre.x + rHub * 0.65f, centre.y + rHub * 0.75f, true);
+        g.setGradientFill(cap);
+        g.fillEllipse(centre.x - rHub, centre.y - rHub, rHub * 2.0f, rHub * 2.0f);
+        g.setColour(juce::Colours::black.withAlpha(0.48f));
+        g.drawEllipse(centre.x - rHub, centre.y - rHub, rHub * 2.0f, rHub * 2.0f, 1.0f);
+
+        g.setColour(juce::Colours::white.withAlpha(0.20f));
+        g.fillEllipse(centre.x - rHub * 0.45f, centre.y - rHub * 0.55f, rHub * 0.55f, rHub * 0.38f);
     }
 }

--- a/Source/VintageLookAndFeel.h
+++ b/Source/VintageLookAndFeel.h
@@ -6,7 +6,7 @@
 
 class VintageLookAndFeel : public juce::LookAndFeel_V4 {
 public:
-    VintageLookAndFeel() = default;
+    VintageLookAndFeel();
     ~VintageLookAndFeel() override = default;
 
     void drawRotarySlider(juce::Graphics& g, int x, int y, int width, int height,


### PR DESCRIPTION
## Summary

- Redesigns the rotary knob look with a brighter champagne face, bakelite-style outer ring, brass scale, and ruby pointer.
- Updates slider text box and label styling to better match the retro GUI.
- Adjusts knob sizing, spacing, and adds a subtle control shelf behind the knobs.

## Validation

- Confirmed the original JUCE compatibility error was fixed by removing the unsupported `textBoxHighlightedTextColourId` colour ID.
- Earlier local CMake configuration succeeded, but full local build in this environment is blocked because `JuceHeader.h` is unavailable here (`JuceLibraryCode` is not present and no JUCE CMake package is installed).